### PR TITLE
Fixes #109

### DIFF
--- a/metadata/rest/test/__init__.py
+++ b/metadata/rest/test/__init__.py
@@ -95,14 +95,14 @@ class DockerMetadata(object):
     @classmethod
     def stop_elasticsearch_docker(cls):
         """Stop and blow away the elasticsearch docker container."""
-        cls.cli.stop(cls.es_container_id)
+        cls.cli.stop(cls.es_container_id, timeout=20)
         cls.cli.remove_container(cls.es_container_id)
         cls.es_container_id = None
 
     @classmethod
     def stop_postgres_docker(cls):
         """Stop and blow away the postgres docker container."""
-        cls.cli.stop(cls.pg_container_id)
+        cls.cli.stop(cls.pg_container_id, timeout=20)
         cls.cli.remove_container(cls.pg_container_id)
         cls.pg_container_id = None
 

--- a/metadata/rest/test/test_orm.py
+++ b/metadata/rest/test/test_orm.py
@@ -113,7 +113,7 @@ class TestCherryPyAPI(CPCommonTest, helper.CPWebCase):
                                data=txt_trans, headers=self.headers)
             self.assertEqual(req.status_code, 200)
         end_time = time()
-        self.assertTrue(end_time - start_time < 45)
+        self.assertTrue(end_time - start_time < 90)
 
     def test_set_or_create(self):
         """Test the internal set or create method."""


### PR DESCRIPTION
Increasing the Docker.stop timeout from the default of 10s to 20s allows the unit tests to run to completion both locally and remotely